### PR TITLE
Ensure not to delete all cache on post update

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1150,7 +1150,7 @@ function wp_cache_post_id_gc( $siteurl, $post_id, $all = 'all' ) {
 }
 
 function wp_cache_post_change( $post_id ) {
-	global $file_prefix, $cache_path, $blog_id, $super_cache_enabled, $blog_cache_dir, $blogcacheid, $wp_cache_refresh_single_only, $wp_cache_object_cache;
+	global $file_prefix, $cache_path, $blog_id, $super_cache_enabled, $blog_cache_dir, $blogcacheid, $wp_cache_refresh_single_only, $wp_cache_object_cache, $wp_cache_clear_on_post_edit;
 	static $last_processed = -1;
 
 	if ( $post_id == $last_processed ) {
@@ -1177,8 +1177,11 @@ function wp_cache_post_change( $post_id ) {
 			wp_cache_debug( "wp_cache_post_change: comment detected. only deleting post page.", 4 );
 			$all = false;
 		}
-	} else {
+	} elseif( isset( $wp_cache_clear_on_post_edit ) && $wp_cache_clear_on_post_edit ) {
+		wp_cache_debug( "wp_cache_post_change: ensure not to delete all cache on post edit/change, per setting.", 4 );
 		$all = true;
+	} else {
+		$all = false;
 	}
 
 	if ( $wp_cache_object_cache )


### PR DESCRIPTION
https://github.com/Automattic/wp-super-cache/issues/169

On post update `wp_cache_post_edit()` does the test on `$wp_cache_clear_on_post_edit` to decide to clear all cache or not, but when it calls `wp_cache_post_change()` this function can override that setting, so I added the test there too.

ps: sorry this is my first PR ever, I hope I got the procedure right.